### PR TITLE
revlin/activate

### DIFF
--- a/main.js
+++ b/main.js
@@ -157,10 +157,10 @@ define(function (require, exports, module) {
         
         
         var desiredPanelHeight = $(".svg-toolbar", $svgPanel).outerHeight() + viewHeight + (15 * 2);
-        setPanelHeight(desiredPanelHeight);
+        //setPanelHeight(desiredPanelHeight);
         
-        $svgParent.width(viewWidth);
-        $svgParent.height(viewHeight);
+        //$svgParent.width(viewWidth);
+        //$svgParent.height(viewHeight);
     }
     
     /**
@@ -266,7 +266,7 @@ define(function (require, exports, module) {
     
     function createSVGPanel() {
         // Create panel contents
-        $svgPanel = $("<div class='svg-panel inline-widget no-focus'><div class='shadow top'></div><div class='shadow bottom'></div></div>");
+        $svgPanel = $("<div id='svg-preview' class='svg-panel inline-widget no-focus'><div class='shadow top'></div><div class='shadow bottom'></div></div>");
         $svgPanel.append("<div class='svg-toolbar'></div><div class='svg-preview checker' style='margin: 15px'></div>");
         var $svgToolbar = $(".svg-toolbar", $svgPanel);
         populateToolbar($svgToolbar);
@@ -315,10 +315,12 @@ define(function (require, exports, module) {
             
             // Inject panel into UI
             // TODO: use PanelManager to create top panel, once possible
+			$("#editor-holder").css('width', "50%");
             $("#editor-holder").before($svgPanel);
             needsWorkspaceLayout = true;
             
         } else if ($svgPanel.is(":hidden")) {
+			$("#editor-holder").css('width', "50%");
             $svgPanel.show();
             needsWorkspaceLayout = true;
         }
@@ -328,6 +330,7 @@ define(function (require, exports, module) {
     
     function hideSVGPanel() {
         if ($svgPanel && $svgPanel.is(":visible")) {
+			$("#editor-holder").css('width', "100%");
             $svgPanel.hide();
             WorkspaceManager.recomputeLayout();
         }

--- a/main.js
+++ b/main.js
@@ -58,7 +58,7 @@ define(function (require, exports, module) {
      *  @type {?{zoomFactor:number}} */
     var currentState;
 	
-	var vertSplit = true,
+	var vertSplit = false,
 		previewActive = false;
     
     
@@ -153,6 +153,7 @@ define(function (require, exports, module) {
 		
 		if( vertSplit ) {
 			$('.svg-panel').css({
+				"float":	"right",
 				"width":	"50%",
 				"height":	"100%"
 			});
@@ -345,10 +346,9 @@ define(function (require, exports, module) {
 		$icon.addClass("active")
 			.unbind("click")
 			.on("click", function(){
+				previewActive = false;
 				hideSVGPanel(editor);
 			});
-		
-		previewActive = true;
     }
     
     function hideSVGPanel(editor) {
@@ -360,10 +360,10 @@ define(function (require, exports, module) {
 			$icon.removeClass("active")
 				.unbind("click")
 				.on("click", function(){
+					previewActive = true;
 					showSVGPanel(editor);
 				});
         }
-		previewActive = false;
     }
     
     /**
@@ -379,6 +379,7 @@ define(function (require, exports, module) {
 					$icon.removeClass("active")
 					.unbind("click")
 					.on("click", function(){
+						previewActive = true;
 						showSVGPanel(newEditor);
 					});
 				}

--- a/main.js
+++ b/main.js
@@ -45,7 +45,8 @@ define(function (require, exports, module) {
      * Preview panel that appears above the editor area. Lazily created, so may be null if never shown yet.
      * @type {?jQuery}
      */
-    var $svgPanel;
+    var $svgPanel,
+		$icon;
     
     /** @type {boolean}  True if panel has just been shown/hidden */
     var needsWorkspaceLayout;
@@ -57,7 +58,8 @@ define(function (require, exports, module) {
      *  @type {?{zoomFactor:number}} */
     var currentState;
 	
-	var vertSplit = true;
+	var vertSplit = true,
+		visibility = false;
     
     
     function attrToPx(attrValue) {
@@ -331,22 +333,37 @@ define(function (require, exports, module) {
 			if( vertSplit ) $("#editor-holder").css('width', "50%");
             $("#editor-holder").before($svgPanel);
             needsWorkspaceLayout = true;
-            
+			
         } else if ($svgPanel.is(":hidden")) {
 			if( vertSplit ) $("#editor-holder").css('width', "50%");
             $svgPanel.show();
             needsWorkspaceLayout = true;
         }
         
-        attachToEditor(editor);
+        	attachToEditor(editor);
+		
+		$icon.addClass("active")
+			.unbind("click")
+			.on("click", function(){
+				hideSVGPanel(editor);
+			});
+		
+		visibility = true;
     }
     
-    function hideSVGPanel() {
+    function hideSVGPanel(editor) {
         if ($svgPanel && $svgPanel.is(":visible")) {
 			$("#editor-holder").css('width', "100%");
             $svgPanel.hide();
             WorkspaceManager.recomputeLayout();
+		
+			$icon.removeClass("active")
+				.unbind("click")
+				.on("click", function(){
+					showSVGPanel(editor);
+				});
         }
+		visibility = false;
     }
     
     /**
@@ -357,9 +374,18 @@ define(function (require, exports, module) {
         var newEditor = EditorManager.getCurrentFullEditor();
         if (newEditor) {
             if (newEditor.document.getLanguage().getId() === "svg") {
-                showSVGPanel(newEditor);
+                if( visibility ) showSVGPanel(newEditor);
+				else {
+					$icon.removeClass("active")
+					.unbind("click")
+					.on("click", function(){
+						showSVGPanel(newEditor);
+					});
+				}
+				$icon.css({display: "block"});
             } else {
                 hideSVGPanel();
+				$icon.css({display: "none"});
             }
         } else {
             hideSVGPanel();
@@ -375,4 +401,15 @@ define(function (require, exports, module) {
             // Don't pick up initially visible editor until our stylesheet is loaded
             handleCurrentEditorChange();
         });
+	
+    // Add toolbar icon 
+    $icon = $("<a>")
+        .attr({
+            id: "svg-preview-icon",
+            href: "#"
+        })
+        .css({
+            display: "none"
+        })
+        .appendTo($("#main-toolbar .buttons"));
 });

--- a/main.js
+++ b/main.js
@@ -56,6 +56,8 @@ define(function (require, exports, module) {
     /** State of the panel for the currently viewed Document, or null if panel not currently shown
      *  @type {?{zoomFactor:number}} */
     var currentState;
+	
+	var vertSplit = true;
     
     
     function attrToPx(attrValue) {
@@ -84,7 +86,7 @@ define(function (require, exports, module) {
     
     function limitDecimals(num, nDecimals) {
         return parseFloat(num.toFixed(nDecimals));
-    }
+	}
     
     function setPanelHeight(height) {
         if (height !== $svgPanel.lastHeight || needsWorkspaceLayout) {
@@ -142,10 +144,20 @@ define(function (require, exports, module) {
             viewHeight = maxHeight;
             viewWidth = maxHeight * svgWidth / svgHeight;
         }
-        $(".svg-tb-button.zoom11-icon", $svgPanel).toggleClass("disabled", svgHeight > maxHeight);
+        //$(".svg-tb-button.zoom11-icon", $svgPanel).toggleClass("disabled", svgHeight > maxHeight);
         $(".svg-tb-button.zoomin-icon", $svgPanel).toggleClass("disabled", viewHeight * 2 > maxHeight);
         
         $(".svg-tb-label", $svgPanel).text(limitDecimals((viewWidth / svgWidth) * 100, 2) + "%");
+		
+		if( vertSplit ) {
+			$('.svg-panel').css({
+				"width":	"50%",
+				"height":	"100%"
+			});
+			
+			viewWidth = "95%";
+			//viewHeight ="95%";
+		}
         
         // jQ auto lowercases the attr name, making it ignored (http://bugs.jquery.com/ticket/11166 wontfix: "we don't support SVG")
         if (!viewBoxAttr) {
@@ -157,10 +169,10 @@ define(function (require, exports, module) {
         
         
         var desiredPanelHeight = $(".svg-toolbar", $svgPanel).outerHeight() + viewHeight + (15 * 2);
-        //setPanelHeight(desiredPanelHeight);
+        if(! vertSplit ) setPanelHeight(desiredPanelHeight);
         
-        //$svgParent.width(viewWidth);
-        //$svgParent.height(viewHeight);
+        $svgParent.width(viewWidth); 
+        $svgParent.height(viewHeight); 
     }
     
     /**
@@ -293,6 +305,7 @@ define(function (require, exports, module) {
             };
         }
         currentState = editor.svgPanelState;
+		currentState.zoomFactor = 0.5;
         
         // Update panel when text changes
         editor.document.on("change", handleDocumentChange);
@@ -315,12 +328,12 @@ define(function (require, exports, module) {
             
             // Inject panel into UI
             // TODO: use PanelManager to create top panel, once possible
-			$("#editor-holder").css('width', "50%");
+			if( vertSplit ) $("#editor-holder").css('width', "50%");
             $("#editor-holder").before($svgPanel);
             needsWorkspaceLayout = true;
             
         } else if ($svgPanel.is(":hidden")) {
-			$("#editor-holder").css('width', "50%");
+			if( vertSplit ) $("#editor-holder").css('width', "50%");
             $svgPanel.show();
             needsWorkspaceLayout = true;
         }

--- a/main.js
+++ b/main.js
@@ -59,7 +59,7 @@ define(function (require, exports, module) {
     var currentState;
 	
 	var vertSplit = true,
-		visibility = false;
+		previewActive = false;
     
     
     function attrToPx(attrValue) {
@@ -141,7 +141,7 @@ define(function (require, exports, module) {
         var viewHeight = svgHeight * currentState.zoomFactor;
 
         // Clip to max of 3/4 window ht
-        var maxHeight = $(".content").height() * 3 / 4;
+        var maxHeight = ( vertSplit )? $(".content").height() : $(".content").height() * 3 / 4;
         if (viewHeight > maxHeight) {
             viewHeight = maxHeight;
             viewWidth = maxHeight * svgWidth / svgHeight;
@@ -348,7 +348,7 @@ define(function (require, exports, module) {
 				hideSVGPanel(editor);
 			});
 		
-		visibility = true;
+		previewActive = true;
     }
     
     function hideSVGPanel(editor) {
@@ -363,7 +363,7 @@ define(function (require, exports, module) {
 					showSVGPanel(editor);
 				});
         }
-		visibility = false;
+		previewActive = false;
     }
     
     /**
@@ -374,7 +374,7 @@ define(function (require, exports, module) {
         var newEditor = EditorManager.getCurrentFullEditor();
         if (newEditor) {
             if (newEditor.document.getLanguage().getId() === "svg") {
-                if( visibility ) showSVGPanel(newEditor);
+                if( previewActive ) showSVGPanel(newEditor);
 				else {
 					$icon.removeClass("active")
 					.unbind("click")

--- a/svg-preview-tool.svg
+++ b/svg-preview-tool.svg
@@ -3,13 +3,13 @@
  <title>SVG Preview</title>
 
  <g>
-  <title>Layer 1</title>
   <g id="svg-preview">
-   <rect font-size="8" ry="2" rx="2" id="svg_1" height="12.147034" width="17.886841" y="5.938614" x="3.196739" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="null" fill="#BBBBBB"/>
-   <text transform="matrix(0.999758, 0, 0, 1, -20.6192, 0)" xml:space="preserve" text-anchor="middle" font-family="serif" font-size="8" id="svg_3" y="15.037766" x="32.433553" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="0" fill="#ffffff">SVG</text>
+   <rect ry="2" rx="2" id="svg_1" height="12.147034" width="17.886841" y="5.938614" x="3.196739" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="null" fill="#BBBBBB"/>
+   <text transform="matrix(0.999758, 0, 0, 1, -20.6192, 0)" xml:space="preserve" text-anchor="middle" font-family="sans-serif" font-size="8" id="svg_3" y="15.037766" x="32.433553" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="0" fill="#333">SVG</text>
   </g>
   <g id="svg-preview-on">
-   <rect id="svg_6" font-size="8" ry="2" rx="2" height="12.147034" width="17.886841" y="29.83223" x="2.929771" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="null" fill="#007fff"/>
-   <text id="svg_7" transform="matrix(0.999758, 0, 0, 1, -20.6192, 0)" xml:space="preserve" text-anchor="middle" font-family="serif" font-size="8" y="38.931381" x="32.300037" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="0" fill="#ffffff">SVG</text>
+   <rect ry="2" rx="2" height="12.147034" width="17.886841" y="29.83223" x="2.929771" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="null" fill="#007fff"/>
+   <text transform="matrix(0.999758, 0, 0, 1, -20.6192, 0)" xml:space="preserve" text-anchor="middle" font-family="sans-serif" font-size="8" y="38.931381" x="32.300037" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="0" fill="#FFF">SVG</text>
   </g>
- </g></svg>
+ </g>
+</svg>

--- a/svg-preview-tool.svg
+++ b/svg-preview-tool.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<svg width="24.000000000000004" height="48.00000000000001" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <title>SVG Preview</title>
+
+ <g>
+  <title>Layer 1</title>
+  <g id="svg-preview">
+   <rect font-size="8" ry="2" rx="2" id="svg_1" height="12.147034" width="17.886841" y="5.938614" x="3.196739" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="null" fill="#BBBBBB"/>
+   <text transform="matrix(0.999758, 0, 0, 1, -20.6192, 0)" xml:space="preserve" text-anchor="middle" font-family="serif" font-size="8" id="svg_3" y="15.037766" x="32.433553" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="0" fill="#ffffff">SVG</text>
+  </g>
+  <g id="svg-preview-on">
+   <rect id="svg_6" font-size="8" ry="2" rx="2" height="12.147034" width="17.886841" y="29.83223" x="2.929771" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="null" fill="#007fff"/>
+   <text id="svg_7" transform="matrix(0.999758, 0, 0, 1, -20.6192, 0)" xml:space="preserve" text-anchor="middle" font-family="serif" font-size="8" y="38.931381" x="32.300037" stroke-linecap="null" stroke-linejoin="null" stroke-dasharray="null" stroke-width="0" fill="#ffffff">SVG</text>
+  </g>
+ </g></svg>

--- a/svg-preview.css
+++ b/svg-preview.css
@@ -1,5 +1,8 @@
 .svg-panel {
     position: relative; /* positioning context for shadows */
+	float:	right;
+	width:	50%;
+	height:	100%;
 }
 .svg-panel .shadow.top {
     top: 29px; /* place below toolbar */

--- a/svg-preview.css
+++ b/svg-preview.css
@@ -51,3 +51,12 @@
 .zoomin-icon    { background-position: 0 0; }
 .zoomout-icon   { background-position: 0 -20px; }
 .zoom11-icon    { background-position: 0 -40px; }
+
+/* Toolbar icon */
+#svg-preview-icon {
+    background-image: url(svg-preview-tool.svg);
+}
+
+#svg-preview-icon.active {
+    background-position: 0 -24px !important;
+}

--- a/svg-preview.css
+++ b/svg-preview.css
@@ -1,8 +1,6 @@
 .svg-panel {
     position: relative; /* positioning context for shadows */
-	float:	right;
-	width:	50%;
-	height:	100%;
+	float:	right; 
 }
 .svg-panel .shadow.top {
     top: 29px; /* place below toolbar */

--- a/svg-preview.css
+++ b/svg-preview.css
@@ -1,6 +1,5 @@
 .svg-panel {
     position: relative; /* positioning context for shadows */
-	float:	right; 
 }
 .svg-panel .shadow.top {
     top: 29px; /* place below toolbar */


### PR DESCRIPTION
Added an icon to the Brackets side-bar, which can be used to activate/deactivate preview when viewing SVG files. This became useful after a vertical-split property (`vertSplit`) was added to the source, allowing the preview to be rendered side-by-side with the SVG source, rather than above. The horizontal-split is still the default view.
